### PR TITLE
Includable module

### DIFF
--- a/lib/in_business.rb
+++ b/lib/in_business.rb
@@ -1,69 +1,76 @@
 require 'ostruct'
 require 'active_support/core_ext'
+require 'active_support/concern'
 
 module InBusiness
+  extend ActiveSupport::Concern
 
-  @holidays = []
-  @hours = OpenStruct.new
-  
-  def self.holidays
-    @holidays
+  included do
+    include InstanceMethods
   end
 
-  def self.holidays=(array)
-    @holidays = array
-  end
-
-  def self.hours
-    @hours
-  end
-
-  def self.hours=(hash)
-    @hours = OpenStruct.new(hash)
-  end
-
-  def self.reset
-    # Used for clearing the state of InBusiness between specs
-    @holidays = []
-    @hours = OpenStruct.new
-    true
-  end
-
-  def self.open?(datetime=DateTime.now)
-    
-    # If this is included in the list of holidays, return false
-    return false if is_holiday? datetime
-
-    # If we don't know the opening hours for datetime's day, assume we're closed
-    return false unless hours.send(days[datetime.wday.to_s].to_sym)
-
-    # We have opening hours, so check if the current time is within them
-    if !hours.send(days[datetime.wday.to_s].to_sym).include? datetime.strftime("%H:%M")
-      return false
+  module InstanceMethods
+    def holidays
+      @holidays ||= []
     end
 
-    true # It's not not open, so it must be open ;)
+    def holidays=(array)
+      @holidays = array
+    end
+
+    def hours
+      @hours ||= OpenStruct.new
+    end
+
+    def hours=(hash)
+      @hours = OpenStruct.new(hash)
+    end
+
+    def reset
+      # Used for clearing the state of InBusiness between specs
+      self.holidays = []
+      self.hours = {}
+      true
+    end
+
+    def open?(datetime=DateTime.now)
+      
+      # If this is included in the list of holidays, return false
+      return false if is_holiday? datetime
+
+      # If we don't know the opening hours for datetime's day, assume we're closed
+      return false unless hours.send(days[datetime.wday.to_s].to_sym)
+
+      # We have opening hours, so check if the current time is within them
+      if !hours.send(days[datetime.wday.to_s].to_sym).include? datetime.strftime("%H:%M")
+        return false
+      end
+
+      true # It's not not open, so it must be open ;)
+    end
+
+    def closed?(datetime=DateTime.now)
+      !open?(datetime)
+    end
+
+    def is_holiday?(date=DateTime.now)
+      holidays.include? date.to_date
+    end
+
+    # Maps values of [DateTime/Date/Time]#wday to English days
+    def days
+      {
+        "0" => "sunday",
+        "1" => "monday",
+        "2" => "tuesday",
+        "3" => "wednesday",
+        "4" => "thursday",
+        "5" => "friday",
+        "6" => "saturday"
+      }
+    end
   end
 
-  def self.closed?(datetime=DateTime.now)
-    !open?(datetime)
-  end
-
-  def self.is_holiday?(date=DateTime.now)
-    @holidays.include? date.to_date
-  end
-
-  # Maps values of [DateTime/Date/Time]#wday to English days
-  def self.days
-    {
-      "0" => "sunday",
-      "1" => "monday",
-      "2" => "tuesday",
-      "3" => "wednesday",
-      "4" => "thursday",
-      "5" => "friday",
-      "6" => "saturday"
-    }
-  end
-
+  # Extend so one can use InBusiness as a singleton module
+  extend InstanceMethods
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,5 +13,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = 'random'
+  # config.order = 'random'
 end

--- a/spec/used_as_module_spec.rb
+++ b/spec/used_as_module_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'delegate'
+
+class MyClass
+  include InBusiness
+end
+
+describe "Using InBusiness as a module" do
+  subject do
+    MyClass.new
+  end
+
+  describe "it responds to the same API as InBusiness" do
+    it { should respond_to(:open?) }
+    it { should respond_to(:closed?) }
+    it { should respond_to(:hours) }
+    it { should respond_to(:hours=) }
+    it { should respond_to(:holidays) }
+    it { should respond_to(:holidays=) }
+    it { should respond_to(:reset) }
+    it { should respond_to(:is_holiday?) }
+    it { should respond_to(:days) }
+  end
+end


### PR DESCRIPTION
Make `InBusiness` includable while supporting the singleton API.
### Example

``` ruby
class MyClass
  include InBusiness
end

instance = MyClass.new
instance.hours = {
  monday: "15:00".."18:00"
}
instance.hours.monday
# => "15:00".."18:00"
```

It should respond to all the methods that the singleton API currently have :)
