### PR TITLE
use cover? over include?

### DIFF
--- a/lib/in_business.rb
+++ b/lib/in_business.rb
@@ -42,7 +42,7 @@ module InBusiness
       return false unless hours.send(days[datetime.wday.to_s].to_sym)
 
       # We have opening hours, so check if the current time is within them
-      if !hours.send(days[datetime.wday.to_s].to_sym).include? datetime.strftime("%H:%M")
+      if !hours.send(days[datetime.wday.to_s].to_sym).cover? datetime.strftime("%H:%M")
         return false
       end
 


### PR DESCRIPTION
`include?` checks every possible object in the range, whereas `cover?` checks the first and last, and if what is past is in between.

This means it's a bit quicker for doing comparisons like this when you can compare with some greater than or less than operations, rather than having to check every object in the potential range.

See https://gist.github.com/julian7/4055746 for some benchmarks (although benchmarks on their own are often worthless, granted).

Awesome gem btw - have it starred for a future side project of mine and noticed this so thought I'd send a PR :)
